### PR TITLE
Sorting and Date

### DIFF
--- a/src/components/posts/MyPosts.js
+++ b/src/components/posts/MyPosts.js
@@ -56,7 +56,7 @@ export const MyPosts = () => {
         () => {
             const sortPosts = filteredPosts.sort((a, b) => (b.publication_date - a.publication_date) ? 1 : -1)
             setDateSortedPosts(sortPosts)
-        }
+        }, []
     )
 
     return <article className="allPosts">

--- a/src/components/posts/MyPosts.js
+++ b/src/components/posts/MyPosts.js
@@ -54,9 +54,9 @@ export const MyPosts = () => {
 
     useEffect(
         () => {
-            const sortPosts = filteredPosts.sort((a, b) => (b.publication_date - a.publication_date) ? 1 : -1)
+            const sortPosts = filteredPosts.sort((a, b) => (a.publication_date - b.publication_date) ? -1 : 1)
             setDateSortedPosts(sortPosts)
-        }, []
+        }, [filteredPosts]
     )
 
     return <article className="allPosts">

--- a/src/components/posts/PostForm.js
+++ b/src/components/posts/PostForm.js
@@ -30,8 +30,10 @@ export const AddPost = () => {
     const formatDate = date.toLocaleString('en-us', {
         minimumIntegerDigits: 2
     })
-    const today = year + "-" + month + "-" + formatDate
-    
+    const formatMonth = month.toLocaleString('en-us', {
+        minimumIntegerDigits: 2
+    })
+    const today = year + "-" + formatMonth + "-" + formatDate
 
     const navigate = useNavigate()
     const localForumUser = localStorage.getItem("forum_user")

--- a/src/components/posts/PostForm.js
+++ b/src/components/posts/PostForm.js
@@ -27,7 +27,11 @@ export const AddPost = () => {
     const month = newDate.getUTCMonth() +1
     const date = newDate.getUTCDate()
     const year = newDate.getUTCFullYear()
-    const today = year + "-" + month + "-" + date
+    const formatDate = date.toLocaleString('en-us', {
+        minimumIntegerDigits: 2
+    })
+    const today = year + "-" + month + "-" + formatDate
+    
 
     const navigate = useNavigate()
     const localForumUser = localStorage.getItem("forum_user")

--- a/src/components/posts/PostList.js
+++ b/src/components/posts/PostList.js
@@ -48,9 +48,9 @@ export const AllPosts = () => {
 
     useEffect(
         () => {
-            const sortPosts = allPosts.sort((a, b) => (b.publication_date - a.publication_date) ? 1 : -1)
+            const sortPosts = allPosts.sort((a, b) => (a.publication_date - b.publication_date) ? -1 : 1)
             setDateSortedPosts(sortPosts)
-        }
+        }, [allPosts]
     )
 
 


### PR DESCRIPTION
## Description

Posts now sort properly;

Added a format to the date to force 2 digits for month and day.  Would cause problems sorting by date if month or day only had 1 digit.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

To test this branch:
  - Git fetch --all
  - Git checkout nm-rare-client
  - [ ] Test A -When making a new post; date is formatted to always two digits on month and day
  - [ ] Test B - All posts and My posts are in correct descending order.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
